### PR TITLE
도메인 엔티티 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,18 @@ repositories {
 }
 
 dependencies {
+    /** starter **/
     implementation 'org.springframework.boot:spring-boot-starter'
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    /** lombok **/
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    /** persistence **/
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
     /** persistence **/
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    /** validation **/
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/clush/assignment/domain/schedule/entity/Calendar.java
+++ b/src/main/java/com/clush/assignment/domain/schedule/entity/Calendar.java
@@ -1,0 +1,16 @@
+package com.clush.assignment.domain.schedule.entity;
+
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Calendar extends Schedule{
+
+    private LocalDateTime eventDateTime;
+}

--- a/src/main/java/com/clush/assignment/domain/schedule/entity/Calendar.java
+++ b/src/main/java/com/clush/assignment/domain/schedule/entity/Calendar.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Calendar extends Schedule{
+public final class Calendar extends Schedule{
 
     private LocalDateTime eventDateTime;
 }

--- a/src/main/java/com/clush/assignment/domain/schedule/entity/Calendar.java
+++ b/src/main/java/com/clush/assignment/domain/schedule/entity/Calendar.java
@@ -4,13 +4,23 @@ import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public final class Calendar extends Schedule{
+public final class Calendar extends Schedule {
 
     private LocalDateTime eventDateTime;
+
+    public Calendar(
+            @NonNull String title,
+            String description,
+            @NonNull LocalDateTime eventDateTime
+    ) {
+        super(title, description);
+        this.eventDateTime = eventDateTime;
+    }
 }

--- a/src/main/java/com/clush/assignment/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/clush/assignment/domain/schedule/entity/Schedule.java
@@ -1,6 +1,7 @@
 package com.clush.assignment.domain.schedule.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,18 +17,26 @@ public abstract class Schedule {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
     private String title;
 
     private String description;
 
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
+
+    public Schedule(String title, String description) {
+        this.title = title;
+        this.description = description;
+    }
 
     @PrePersist
     public void prePersist() {
         this.createdAt = LocalDateTime.now();
-        this.updatedAt= LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
     }
 
     @PreUpdate

--- a/src/main/java/com/clush/assignment/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/clush/assignment/domain/schedule/entity/Schedule.java
@@ -1,0 +1,38 @@
+package com.clush.assignment.domain.schedule.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+public abstract class Schedule {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String description;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt= LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/clush/assignment/domain/schedule/entity/Todo.java
+++ b/src/main/java/com/clush/assignment/domain/schedule/entity/Todo.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Todo extends Schedule{
+public final class Todo extends Schedule{
 
     private Boolean completed;
 }

--- a/src/main/java/com/clush/assignment/domain/schedule/entity/Todo.java
+++ b/src/main/java/com/clush/assignment/domain/schedule/entity/Todo.java
@@ -1,0 +1,14 @@
+package com.clush.assignment.domain.schedule.entity;
+
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Todo extends Schedule{
+
+    private Boolean completed;
+}

--- a/src/main/java/com/clush/assignment/domain/schedule/entity/Todo.java
+++ b/src/main/java/com/clush/assignment/domain/schedule/entity/Todo.java
@@ -4,11 +4,21 @@ import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public final class Todo extends Schedule{
+public final class Todo extends Schedule {
 
     private Boolean completed;
+
+    public Todo(
+            @NonNull String title,
+            String description,
+            @NonNull Boolean completed
+    ) {
+        super(title, description);
+        this.completed = completed;
+    }
 }


### PR DESCRIPTION
## 개요

- 도메인 엔티티 생성

## 본문

Todo, Calendar 엔티티를 생성하고 공통된 필드와 로직을 추상화한 Schedule 엔티티를 생성하였습니다.