### PR TITLE
캘린더 업데이트 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ repositories {
     mavenCentral()
 }
 
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
 dependencies {
     /** spring app **/
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/clush/assignment/domain/schedule/controller/CalendarController.java
+++ b/src/main/java/com/clush/assignment/domain/schedule/controller/CalendarController.java
@@ -6,6 +6,7 @@ import com.clush.assignment.domain.schedule.dto.response.BasicCalendarResDto;
 import com.clush.assignment.domain.schedule.service.calendar.CreateCalendarService;
 import com.clush.assignment.domain.schedule.service.calendar.QueryAllCalendarsService;
 import com.clush.assignment.domain.schedule.service.calendar.QueryCalendarsService;
+import com.clush.assignment.domain.schedule.service.calendar.UpdateCalendarByIdService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +22,7 @@ public class CalendarController {
     private final CreateCalendarService createCalendarsService;
     private final QueryCalendarsService queryCalendarsService;
     private final QueryAllCalendarsService queryAllCalendarsService;
+    private final UpdateCalendarByIdService updateCalendarByIdService;
 
     @PostMapping
     public ResponseEntity<Void> create(
@@ -40,5 +42,14 @@ public class CalendarController {
     @GetMapping("/all")
     public ResponseEntity<List<BasicCalendarResDto>> findAll() {
         return ResponseEntity.ok(queryAllCalendarsService.execute());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(
+            @PathVariable("id") Long id,
+            @RequestBody BasicCalendarReqDto basicCalendarReqDto
+    ) {
+        updateCalendarByIdService.execute(id, basicCalendarReqDto);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/clush/assignment/domain/schedule/entity/Calendar.java
+++ b/src/main/java/com/clush/assignment/domain/schedule/entity/Calendar.java
@@ -25,4 +25,14 @@ public final class Calendar extends Schedule {
         super(title, dueDate);
         this.description = description;
     }
+
+    public Calendar(
+            @NonNull Long id,
+            @NonNull String title,
+            String description,
+            @NonNull LocalDateTime dueDate
+    ) {
+        super(id, title, dueDate);
+        this.description = description;
+    }
 }

--- a/src/main/java/com/clush/assignment/domain/schedule/service/calendar/UpdateCalendarByIdService.java
+++ b/src/main/java/com/clush/assignment/domain/schedule/service/calendar/UpdateCalendarByIdService.java
@@ -1,0 +1,31 @@
+package com.clush.assignment.domain.schedule.service.calendar;
+
+import com.clush.assignment.domain.schedule.dto.request.BasicCalendarReqDto;
+import com.clush.assignment.domain.schedule.entity.Calendar;
+import com.clush.assignment.domain.schedule.repository.CalendarRepository;
+import com.clush.assignment.global.exception.ExpectedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateCalendarByIdService {
+
+    private final CalendarRepository calendarRepository;
+
+    public void execute(Long id, BasicCalendarReqDto basicCalendarReqDto) {
+        if (!calendarRepository.existsById(id)) {
+            throw new ExpectedException("해당 id의 calendar가 존재하지 않습니다. id: " + id, HttpStatus.NOT_FOUND);
+        }
+
+        Calendar updatedCalendar = new Calendar(
+                id,
+                basicCalendarReqDto.title(),
+                basicCalendarReqDto.description(),
+                basicCalendarReqDto.dueDateTime()
+        );
+
+        calendarRepository.save(updatedCalendar);
+    }
+}

--- a/src/main/java/com/clush/assignment/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/clush/assignment/global/exception/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.clush.assignment.global.exception.handler;
 
 import com.clush.assignment.global.exception.ExpectedException;
+import com.clush.assignment.global.exception.model.ExceptionResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,35 +18,37 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ExpectedException.class)
-    private ResponseEntity<String> expectedException(ExpectedException ex) {
+    private ResponseEntity<ExceptionResponse> expectedException(ExpectedException ex) {
         log.warn("예상된 예외 발생 : {} ", ex.getMessage());
         log.trace("예상된 예외 세부 정보 : ", ex);
         return ResponseEntity
                 .status(ex.getStatusCode())
-                .body(ex.getMessage());
+                .body(new ExceptionResponse(ex.getMessage()));
     }
 
     @ExceptionHandler({MethodArgumentNotValidException.class, HttpMessageNotReadableException.class})
-    public ResponseEntity<String> validationException(MethodArgumentNotValidException ex) {
+    public ResponseEntity<ExceptionResponse> validationException(MethodArgumentNotValidException ex) {
         log.warn("유효성 검증 실패 : {}", ex.getMessage());
         log.trace("유효성 검증 실패 세부 정보 : ", ex);
         return ResponseEntity
                 .status(ex.getStatusCode())
-                .body(ex.getMessage());
+                .body(new ExceptionResponse(ex.getMessage()));
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
-    public ResponseEntity<String> noHandlerFoundException(NoHandlerFoundException ex) {
+    public ResponseEntity<ExceptionResponse> noHandlerFoundException(NoHandlerFoundException ex) {
         log.warn("존재하지 않는 엔드포인트 요청 : {}", ex.getMessage());
         log.trace("존재하지 않는 엔드포인트 세부 정보 : ", ex);
         return ResponseEntity
                 .status(ex.getStatusCode())
-                .body(ex.getMessage());
+                .body(new ExceptionResponse(ex.getMessage()));
     }
 
     @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<String> unExpectedException(RuntimeException ex) {
+    public ResponseEntity<ExceptionResponse> unExpectedException(RuntimeException ex) {
         log.error("예상하지 못한 예외 발생 : ", ex);
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버에 문제가 발생하였습니다.");
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ExceptionResponse("서버에 문제가 발생하였습니다."));
     }
 }

--- a/src/main/java/com/clush/assignment/global/exception/model/ExceptionResponse.java
+++ b/src/main/java/com/clush/assignment/global/exception/model/ExceptionResponse.java
@@ -1,0 +1,6 @@
+package com.clush.assignment.global.exception.model;
+
+public record ExceptionResponse(
+        String message
+) {
+}


### PR DESCRIPTION
## 개요

- 캘린더를 업데이트하는 기능을 구현하였습니다.
- 전역 예외 핸들러에서 model을 반환하도록 하였습니다.

## 본문

캘린더를 업데이트 하는 api를 구현하였습니다.
전역 예외 핸들러에서 body에 메세지가 아닌 model을 생성후에 메세지를 감싸서 반환하도록 하였습니다.