### PR TITLE
스케줄 추천 기능 구현

### DIFF
--- a/src/main/java/com/clush/assignment/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/clush/assignment/domain/schedule/controller/ScheduleController.java
@@ -19,6 +19,7 @@ public class ScheduleController {
     private final DeleteScheduleByIdService deleteScheduleByIdService;
     private final UpdateBookMarkService updateBookMarkService;
     private final QueryBookMarkService queryBookMarkService;
+    private final QuerySuggestionService querySuggestionService;
 
     @GetMapping
     public ResponseEntity<List<ScheduleResDto>> find(
@@ -51,5 +52,10 @@ public class ScheduleController {
     @GetMapping("/book-mark")
     public ResponseEntity<List<ScheduleResDto>> findBookMark() {
         return ResponseEntity.ok(queryBookMarkService.execute());
+    }
+
+    @GetMapping("/suggestion")
+    public ResponseEntity<List<ScheduleResDto>> suggestion() {
+        return ResponseEntity.ok(querySuggestionService.execute());
     }
 }

--- a/src/main/java/com/clush/assignment/domain/schedule/service/QuerySuggestionService.java
+++ b/src/main/java/com/clush/assignment/domain/schedule/service/QuerySuggestionService.java
@@ -1,0 +1,47 @@
+package com.clush.assignment.domain.schedule.service;
+
+import com.clush.assignment.domain.schedule.dto.response.ScheduleResDto;
+import com.clush.assignment.domain.schedule.entity.Calendar;
+import com.clush.assignment.domain.schedule.entity.Schedule;
+import com.clush.assignment.domain.schedule.entity.Todo;
+import com.clush.assignment.domain.schedule.repository.CalendarRepository;
+import com.clush.assignment.domain.schedule.repository.ScheduleRepository;
+import com.clush.assignment.domain.schedule.repository.TodoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QuerySuggestionService {
+
+    private final TodoRepository todoRepository;
+    private final CalendarRepository calendarRepository;
+    private final ScheduleRepository scheduleRepository;
+
+    public List<ScheduleResDto> execute() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Todo> todoSchedules = todoRepository.findAllByDueDateTimeBetween(now.minusDays(3), now);
+        List<Calendar> calendarSchedules = calendarRepository.findAllByDueDateTimeBetween(now.minusMonths(1), now);
+        List<Schedule> bookMarks = scheduleRepository.findAllByBookMarkIsTrue();
+
+        List<Schedule> randomSchedules = new ArrayList<>();
+        randomSchedules.addAll(getTwoRandomElements(todoSchedules));
+        randomSchedules.addAll(getTwoRandomElements(calendarSchedules));
+        randomSchedules.addAll(getTwoRandomElements(bookMarks));
+
+        return ScheduleResDto.toScheduleDtos(randomSchedules);
+    }
+
+    private <T> List<T> getTwoRandomElements(List<T> elements) {
+        if (elements.size() <= 2) {
+            return new ArrayList<>(elements);
+        }
+        Collections.shuffle(elements);
+        return elements.subList(0, 2);
+    }
+}


### PR DESCRIPTION
## 개요

- 스케줄 추천 기능을 구현하였습니다.

## 본문

스케줄을 추천해주는 api를 구현하였습니다.
추천하는 스케줄을 리스트로 반환합니다.
투두는 최근 3일 안에 생성한 투두를 랜덤으로 2개
캘린더는 최근 한달동안 생성한 캘린더를 랜덤으로 2개
북마크는 북마크한 스케줄중 랜덤으로 2개

총 6개의 요소를 리스트에 담아서 반환합니다.